### PR TITLE
Ошибочный импорт в main.scss

### DIFF
--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -7,7 +7,6 @@
 
 @import './base/reset';
 @import './utils/variables.scss'; //Colors palette
-@import './components/hero-headder';
 @import './components/hero-header';
 @import './components/products';
 @import './components/about';


### PR DESCRIPTION
Удалил импорт который вызывал ошибку при выполнении команды npm run dev
×  D:\Users\Arlth\Documents\GitHub\DepecheCode\src\sass\main.scss:10:9: Can't find stylesheet to import.
   ╷
10 │ @import './components/hero-headder';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  src\sass\main.scss 10:9  root stylesheet
Error: Can't find stylesheet to import.